### PR TITLE
Add possibility to override the default Host and DNS names

### DIFF
--- a/resources/ec2/instance.yaml
+++ b/resources/ec2/instance.yaml
@@ -1099,7 +1099,8 @@ Resources:
           commands:
             0100_sysconfig:
               command: !Sub
-                - "echo HOSTNAME=${ActualHostName} >> /etc/sysconfig/network"
+                # "Fn::Sub" prevents bash parameter substitution, so we use "sed" instead
+                - "HOSTNAME=$(echo ${ActualHostName}-${HostedZoneName} | sed 's/\\./-/g'); echo HOSTNAME=$HOSTNAME >> /etc/sysconfig/network"
                 - ActualHostName: !If
                     - HasHostName
                     - !Ref HostName
@@ -1107,7 +1108,8 @@ Resources:
             0200_systemd:
               test: 'test $(ps --no-headers -o comm 1) == "systemd"'
               command: !Sub
-                - "hostnamectl set-hostname ${ActualHostName}"
+                # "Fn::Sub" prevents bash parameter substitution, so we use "sed" instead
+                - "HOSTNAME=$(echo ${ActualHostName}-${HostedZoneName} | sed 's/\\./-/g'); hostnamectl set-hostname $HOSTNAME"
                 - ActualHostName: !If
                     - HasHostName
                     - !Ref HostName
@@ -1211,7 +1213,10 @@ Resources:
       Parameters:
         # DNS Record configuration
         #
-        DnsName: !Sub "${RootStackName}-${Designation}"
+        DnsName: !If
+          - HasHostName
+          - !Ref HostName
+          - !Sub "${RootStackName}-${Designation}"
         HostedZoneName: !Ref HostedZoneName
         Target: !GetAtt Instance.PrivateIp
         Type: "A"

--- a/resources/elb/alb.yaml
+++ b/resources/elb/alb.yaml
@@ -106,6 +106,7 @@ Metadata:
     - Label:
         default: "DNS Record configuration (optional)"
       Parameters:
+      - DnsName
       - DnsServiceToken
       - HostedZoneName
       - TimeToLive
@@ -300,6 +301,11 @@ Parameters:
   # DNS Record configuration (optional)
   #=======================================
 
+  DnsName:
+    Description: "The name that will be used for this load balancers DNS name (example: \"a.assets\"; default: \"${RootStackName}-lb-${Designation}\")."
+    Type: String
+    Default: ""
+
   DnsServiceToken:
     Description: "The SNS Topic ARN or Lambda function ARN that was provided to access the service that manages remote DNS Records (only required if DNS Records are managed in a different account; must be from the same region as this stack)."
     Type: String
@@ -368,6 +374,10 @@ Conditions:
   # If no 3rd Instance has been provided, we won't add a respective target
   Has3rdTarget: !Not
     - !Equals [ !Ref Instance3Id, "" ]
+
+  # Whether DnsName has been explicitly provided or not
+  HasDnsName: !Not
+    - !Equals [ !Ref DnsName, "" ]
 
 
 ################################################################################
@@ -580,7 +590,10 @@ Resources:
       Parameters:
         # DNS Record configuration
         #
-        DnsName: !Sub "${RootStackName}-lb-${Designation}"
+        DnsName: !If
+          - HasDnsName
+          - !Ref DnsName
+          - !Sub "${RootStackName}-lb-${Designation}"
         HostedZoneName: !Ref HostedZoneName
         Target: !GetAtt ApplicationLoadBalancer.DNSName
         TimeToLive: !Ref TimeToLive

--- a/stacks/appenv/aem/env.yaml
+++ b/stacks/appenv/aem/env.yaml
@@ -60,6 +60,7 @@ Metadata:
     - Label:
         default: "Environment configuration"
       Parameters:
+      - HostNameSuffix
       - IamInstanceProfile
       - IamManagedPolicies
       - RootKeyName
@@ -111,6 +112,7 @@ Metadata:
     - Label:
         default: "Author"
       Parameters:
+      - AuthorDesignation
       - AuthorImageId
       - AuthorInstanceType
       - AuthorRootDeviceName
@@ -133,6 +135,7 @@ Metadata:
     - Label:
         default: "Author Dispatcher (optional)"
       Parameters:
+      - AuthorDispatcherDesignation
       - AuthorDispatcherImageId
       - AuthorDispatcherInstanceType
       - AuthorDispatcherRootDeviceName
@@ -147,6 +150,7 @@ Metadata:
     - Label:
         default: "Publish"
       Parameters:
+      - PublishDesignation
       - PublishImageId
       - PublishInstanceType
       - PublishRootDeviceName
@@ -169,6 +173,7 @@ Metadata:
     - Label:
         default: "Publish Dispatcher (optional)"
       Parameters:
+      - PublishDispatcherDesignation
       - PublishDispatcherImageId
       - PublishDispatcherInstanceType
       - PublishDispatcherRootDeviceName
@@ -208,6 +213,11 @@ Parameters:
   #=======================================
   # Environment configuration
   #=======================================
+
+  HostNameSuffix:
+    Description: "A string that will be appended to the designation string of all Instances, creating their host name (examples: \".dev\", \".assets.uat\")."
+    Type: String
+    Default: ""
 
   IamInstanceProfile:
     Description: "The ARN of an IAM Instance Profile that is used to grant permissions to the EC2 Instances of this environment (takes precedence over IamManagedPolicies)."
@@ -401,6 +411,11 @@ Parameters:
   # AEM Author
   #=======================================
 
+  AuthorDesignation:
+    Description: "A string that will be used to represent the Author Instance, for example in its host and DNS name."
+    Type: String
+    Default: ""
+
   AuthorImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Author Instance will be created from."
     Type: AWS::EC2::Image::Id
@@ -508,6 +523,11 @@ Parameters:
   # Author Dispatcher (optional)
   #=======================================
 
+  AuthorDispatcherDesignation:
+    Description: "A string that will be used to represent the Author Dispatcher Instance, for example in its host and DNS name."
+    Type: String
+    Default: ""
+
   AuthorDispatcherImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Author Dispatcher Instance will be created from (if this value is empty the Instance will not be created)."
     Type: String
@@ -568,6 +588,11 @@ Parameters:
   #=======================================
   # AEM Publish
   #=======================================
+
+  PublishDesignation:
+    Description: "A string that will be used to represent the Publish Instance, for example in its host and DNS name."
+    Type: String
+    Default: ""
 
   PublishImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Publish Instance will be created from."
@@ -670,6 +695,11 @@ Parameters:
   #=======================================
   # Publish Dispatcher (optional)
   #=======================================
+
+  PublishDispatcherDesignation:
+    Description: "A string that will be used to represent the Publish Dispatcher Instance, for example in its host and DNS name."
+    Type: String
+    Default: ""
 
   PublishDispatcherImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Publish Dispatcher Instance will be created from (if this value is empty the Instance will not be created)."
@@ -788,6 +818,14 @@ Conditions:
   CreatePublishDispatcherInstance: !Not
     - !Equals [ !Ref PublishDispatcherImageId, "" ]
 
+  # Whether AuthorDesignation has been specified or not
+  HasAuthorDesignation: !Not
+    - !Equals [ !Ref AuthorDesignation, "" ]
+
+  # Whether AuthorDispatcherDesignation has been specified or not
+  HasAuthorDispatcherDesignation: !Not
+    - !Equals [ !Ref AuthorDispatcherDesignation, "" ]
+
   # Whether an IAM Instance Profile has been provided or not
   HasIamInstanceProfile: !Not
     - !Equals [ !Ref IamInstanceProfile, "" ]
@@ -797,6 +835,14 @@ Conditions:
     - !Equals
       - !Join [ "", !Ref IamManagedPolicies ]
       - ""
+
+  # Whether PublishDesignation has been specified or not
+  HasPublishDesignation: !Not
+    - !Equals [ !Ref PublishDesignation, "" ]
+
+  # Whether PublishDispatcherDesignation has been specified or not
+  HasPublishDispatcherDesignation: !Not
+    - !Equals [ !Ref PublishDispatcherDesignation, "" ]
 
   # Whether a additional Security Groups have been specified for the Author Instance (the join is necessary to transform the list to a string that we can compare)
   HasAuthorSecurityGroups: !Not
@@ -975,6 +1021,10 @@ Resources:
 
         # Author
         #
+        AuthorHostName: !If
+          - HasAuthorDesignation
+          - !Sub "${AuthorDesignation}1${HostNameSuffix}"
+          - !Ref AWS::NoValue
         AuthorImageId: !Ref AuthorImageId
         AuthorInstanceType: !Ref AuthorInstanceType
         AuthorRootDeviceName: !Ref AuthorRootDeviceName
@@ -1013,6 +1063,10 @@ Resources:
 
         # Author Dispatcher (optional; parameters passed here will be ignored if no dispatcher will be created)
         #
+        AuthorDispatcherHostName: !If
+          - HasAuthorDispatcherDesignation
+          - !Sub "${AuthorDispatcherDesignation}1${HostNameSuffix}"
+          - !Ref AWS::NoValue
         AuthorDispatcherImageId: !Ref AuthorDispatcherImageId
         AuthorDispatcherInstanceType: !Ref AuthorDispatcherInstanceType
         AuthorDispatcherRootDeviceName: !Ref AuthorDispatcherRootDeviceName
@@ -1039,6 +1093,10 @@ Resources:
 
         # Publish
         #
+        PublishHostName: !If
+          - HasPublishDesignation
+          - !Sub "${PublishDesignation}1${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishImageId: !Ref PublishImageId
         PublishInstanceType: !Ref PublishInstanceType
         PublishRootDeviceName: !Ref PublishRootDeviceName
@@ -1077,6 +1135,10 @@ Resources:
 
         # Publish Dispatcher (optional; parameters passed here will be ignored if no dispatcher will be created)
         #
+        PublishDispatcherHostName: !If
+          - HasPublishDispatcherDesignation
+          - !Sub "${PublishDispatcherDesignation}1${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishDispatcherImageId: !Ref PublishDispatcherImageId
         PublishDispatcherInstanceType: !Ref PublishDispatcherInstanceType
         PublishDispatcherRootDeviceName: !Ref PublishDispatcherRootDeviceName
@@ -1143,6 +1205,10 @@ Resources:
 
         # Publish
         #
+        PublishHostName: !If
+          - HasPublishDesignation
+          - !Sub "${PublishDesignation}2${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishImageId: !Ref PublishImageId
         PublishInstanceType: !Ref PublishInstanceType
         PublishRootDeviceName: !Ref PublishRootDeviceName
@@ -1181,6 +1247,10 @@ Resources:
 
         # Publish Dispatcher (optional; parameters passed here will be ignored if no dispatcher will be created)
         #
+        PublishDispatcherHostName: !If
+          - HasPublishDispatcherDesignation
+          - !Sub "${PublishDispatcherDesignation}2${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishDispatcherImageId: !Ref PublishDispatcherImageId
         PublishDispatcherInstanceType: !Ref PublishDispatcherInstanceType
         PublishDispatcherRootDeviceName: !Ref PublishDispatcherRootDeviceName
@@ -1247,6 +1317,10 @@ Resources:
 
         # Publish
         #
+        PublishHostName: !If
+          - HasPublishDesignation
+          - !Sub "${PublishDesignation}3${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishImageId: !Ref PublishImageId
         PublishInstanceType: !Ref PublishInstanceType
         PublishRootDeviceName: !Ref PublishRootDeviceName
@@ -1285,6 +1359,10 @@ Resources:
 
         # Publish Dispatcher (optional; parameters passed here will be ignored if no dispatcher will be created)
         #
+        PublishDispatcherHostName: !If
+          - HasPublishDispatcherDesignation
+          - !Sub "${PublishDispatcherDesignation}3${HostNameSuffix}"
+          - !Ref AWS::NoValue
         PublishDispatcherImageId: !Ref PublishDispatcherImageId
         PublishDispatcherInstanceType: !Ref PublishDispatcherInstanceType
         PublishDispatcherRootDeviceName: !Ref PublishDispatcherRootDeviceName
@@ -1453,6 +1531,10 @@ Resources:
 
         # DNS Record configuration (optional)
         #
+        DnsName: !If
+          - HasAuthorDesignation
+          - !Sub "${AuthorDesignation}${HostNameSuffix}"
+          - !Ref AWS::NoValue
         DnsServiceToken: !Ref DnsServiceToken
         HostedZoneName: !Ref HostedZoneName
         TimeToLive: !Ref LbTimeToLive
@@ -1532,6 +1614,10 @@ Resources:
 
         # DNS Record configuration (optional)
         #
+        DnsName: !If
+          - HasPublishDesignation
+          - !Sub "${PublishDesignation}${HostNameSuffix}"
+          - !Ref AWS::NoValue
         DnsServiceToken: !Ref DnsServiceToken
         HostedZoneName: !Ref HostedZoneName
         TimeToLive: !Ref LbTimeToLive

--- a/stacks/appenv/aem/hostgroup.yaml
+++ b/stacks/appenv/aem/hostgroup.yaml
@@ -46,6 +46,7 @@ Metadata:
     - Label:
         default: "Author"
       Parameters:
+      - AuthorHostName
       - AuthorImageId
       - AuthorInstanceType
       - AuthorRootDeviceName
@@ -68,6 +69,7 @@ Metadata:
     - Label:
         default: "Author Dispatcher (optional)"
       Parameters:
+      - AuthorDispatcherHostName
       - AuthorDispatcherImageId
       - AuthorDispatcherInstanceType
       - AuthorDispatcherRootDeviceName
@@ -82,6 +84,7 @@ Metadata:
     - Label:
         default: "Publish"
       Parameters:
+      - PublishHostName
       - PublishImageId
       - PublishInstanceType
       - PublishRootDeviceName
@@ -104,6 +107,7 @@ Metadata:
     - Label:
         default: "Publish Dispatcher (optional)"
       Parameters:
+      - PublishDispatcherHostName
       - PublishDispatcherImageId
       - PublishDispatcherInstanceType
       - PublishDispatcherRootDeviceName
@@ -188,6 +192,11 @@ Parameters:
   #=======================================
   # Author (optional)
   #=======================================
+
+  AuthorHostName:
+    Description: "The name that will be used for the Author Instance and, if created, its DNS name."
+    Type: String
+    Default: ""
 
   AuthorImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Author Instance will be created from."
@@ -292,6 +301,11 @@ Parameters:
   # Author Dispatcher (optional)
   #=======================================
 
+  AuthorDispatcherHostName:
+    Description: The name that will be used for the Author Dispatcher Instance and, if created, its DNS name."
+    Type: String
+    Default: ""
+
   AuthorDispatcherImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Author Dispatcher Instance will be created from (if this value is empty the Instance will not be created)."
     Type: String
@@ -352,6 +366,11 @@ Parameters:
   #=======================================
   # Publish
   #=======================================
+
+  PublishHostName:
+    Description: "The name that will be used for the Publish Instance and, if created, its DNS name."
+    Type: String
+    Default: ""
 
   PublishImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Publish Instance will be created from."
@@ -454,6 +473,11 @@ Parameters:
   #=======================================
   # Publish Dispatcher (optional)
   #=======================================
+
+  PublishDispatcherHostName:
+    Description: "The name that will be used for the Publish Dispatcher Instance and, if created, its DNS name."
+    Type: String
+    Default: ""
 
   PublishDispatcherImageId:
     Description: "The unique ID of the Amazon Machine Image (AMI) the Publish Dispatcher Instance will be created from (if this value is empty the Instance will not be created)."
@@ -583,6 +607,7 @@ Resources:
         # Instance configuration
         #
         AvailabilityZone: !Ref AvailabilityZone
+        HostName: !Ref AuthorHostName
         IamInstanceProfile: !Ref IamInstanceProfile
         ImageId: !Ref AuthorImageId
         InstanceType: !Ref AuthorInstanceType
@@ -650,6 +675,7 @@ Resources:
         # Instance configuration
         #
         AvailabilityZone: !Ref AvailabilityZone
+        HostName: !Ref AuthorDispatcherHostName
         IamInstanceProfile: !Ref IamInstanceProfile
         ImageId: !Ref AuthorDispatcherImageId
         InstanceType: !Ref AuthorDispatcherInstanceType
@@ -704,6 +730,7 @@ Resources:
         # Instance configuration
         #
         AvailabilityZone: !Ref AvailabilityZone
+        HostName: !Ref PublishHostName
         IamInstanceProfile: !Ref IamInstanceProfile
         ImageId: !Ref PublishImageId
         InstanceType: !Ref PublishInstanceType
@@ -771,6 +798,7 @@ Resources:
         # Instance configuration
         #
         AvailabilityZone: !Ref AvailabilityZone
+        HostName: !Ref PublishDispatcherHostName
         IamInstanceProfile: !Ref IamInstanceProfile
         ImageId: !Ref PublishDispatcherImageId
         InstanceType: !Ref PublishDispatcherInstanceType

--- a/stacks/appenv/generic/env.yaml
+++ b/stacks/appenv/generic/env.yaml
@@ -38,6 +38,7 @@ Metadata:
     - Label:
         default: "Environment configuration"
       Parameters:
+      - HostNameSuffix
       - IamInstanceProfile
       - IamManagedPolicies
       - RootKeyName
@@ -112,6 +113,11 @@ Parameters:
   #=======================================
   # Environment configuration
   #=======================================
+
+  HostNameSuffix:
+    Description: "A string that will be appended to the designation string of all Instances, creating their host name (examples: \".dev\", \".assets.uat\")."
+    Type: String
+    Default: ""
 
   IamInstanceProfile:
     Description: "The ARN of an IAM Instance Profile that is used to grant permissions to the EC2 Instances of this environment (takes precedence over IamManagedPolicies)."
@@ -437,6 +443,7 @@ Resources:
         # Instance configuration
         #
         AvailabilityZone: !Select [ "0", !Ref HostGroupsAvailabilityZones ]
+        HostName: !Sub "${Designation}${HostNameSuffix}"
         IamInstanceProfile: !Ref IamInstanceProfile
         IamManagedPolicies: !Join [ ",", !Ref IamManagedPolicies ]
         ImageId: !Ref ImageId


### PR DESCRIPTION
The new naming pattern for Host and DNS names now is "<Designation><role_index><HostNameSuffix>"